### PR TITLE
Added support to start specific Android Activity and added possibilit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First, add `flutter_appavailability` as a [dependency in your pubspec.yaml file]
 - `checkAvailability(String uri)`
 - `getInstalledApps()` (only for **Android**)
 - `isAppEnabled(String uri)` (only for **Android**)
-- `launchApp(String uri)`
+- `launchApp(String uri, String activity)`
 
 See the [docs](https://pub.dartlang.org/documentation/flutter_appavailability/latest/).
 
@@ -129,6 +129,13 @@ class _MyAppState extends State<MyApp> {
     );
   }
 }
+
+```
+
+Example starting specific activity on Android. (this is useful if you want to start a specific activity of the app or the app doesn't have a launch intent and is not visible in a launcher)
+```dart
+
+AppAvailability.launchApp('com.example.helloworld', 'com.example.helloworld.settings.main.SettingsActivity');
 
 ```
 

--- a/lib/flutter_appavailability.dart
+++ b/lib/flutter_appavailability.dart
@@ -85,13 +85,14 @@ class AppAvailability {
     return await _channel.invokeMethod("isAppEnabled", args);
   }
 
-  /// Launch an app with the given [uri] scheme if it exists.
+  /// Launch an app with the given [uri] scheme if it exists or if [activity] name is provided [android only].
   ///
   /// If the app app isn't found, then a [PlatformException] is thrown.
-  static Future<void> launchApp(String uri) async {
+  static Future<void> launchApp(String uri, String activity) async {
     Map<String, dynamic> args = <String, dynamic>{};
     args.putIfAbsent('uri', () => uri);
     if (Platform.isAndroid) {
+      args.putIfAbsent('activity', () => activity);
       await _channel.invokeMethod("launchApp", args);
     }
     else if (Platform.isIOS) {


### PR DESCRIPTION
…y to start atleast one of the available activities if it fails to find a launch activity

Added 2 features in the app:

1. Added support to start specific Android Activity.
2. Added support to start other activity if launch activity is not found
- this will make sure the plugin starts any activity available for the app, if it can't find a launch activity, helpful with "hidden apps" which don't have launcher intents, and are not visible in the default launcher